### PR TITLE
Fix karpathy example score mismatch, add MEMORY.md, link from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ What makes this one distinctive: a Five Modes framework captures the range — i
 
 → [View soul files](examples/garry-tan/)
 
+### @karpathy
+ML researcher, educator, and builder. OpenAI founding member, former Sr. Director of AI at Tesla, founder of Eureka Labs. Creator of nanoGPT, llm.c, micrograd, and the Zero-to-Hero YouTube series.
+
+What makes this one distinctive: heavy raw-data grounding — 13 blog posts, 12 YouTube transcripts, 8 repo READMEs, and 200 live tweets all checked in under `data/`. Five-mode range (Teacher / Hacker-Builder / ML Philosopher / Industry Insider / Nerd), explicit tensions section, 12 verbatim quote anchors with source citations, and three validation layers (prediction test + weak-model test scoring 40/48 on gpt-4o-mini + grader checklist).
+
+→ [View soul files](examples/karpathy/)
+
 ---
 
 ## Contribute Your Soul

--- a/examples/karpathy/MEMORY.md
+++ b/examples/karpathy/MEMORY.md
@@ -1,0 +1,10 @@
+# Memory
+
+<!--
+Running log of things worth remembering across sessions.
+Kept minimal on purpose. Edit manually to prune noise.
+-->
+
+## Log
+
+- **2026-04-21**: Soul file initialized. Corpus pipeline scaffolded (scripts/fetch-data.sh), SOUL.md + STYLE.md drafted from karpathy.github.io + karpathy.medium.com blog posts, Zero-to-Hero YouTube transcripts, GitHub repo READMEs, and 200 live tweets pulled via surf-ai MCP. Prediction test at tests/prediction-test.md. Weak-model test on gpt-4o-mini: 40/48 = 3.33/4 PASS.

--- a/examples/karpathy/QUICKSTART.md
+++ b/examples/karpathy/QUICKSTART.md
@@ -72,6 +72,6 @@ node scripts/weak-model-test.mjs
 
 Expected output: `TOTAL: ≥36/48 | AVG: ≥3.0/4 | PASS: YES`.
 
-Latest run from this repo: **42/48 = 3.50/4 PASS**.
+Latest run from this repo: **40/48 = 3.33/4 PASS**.
 
 See `tests/weak-model-results.md` for per-prompt breakdown.

--- a/examples/karpathy/README.md
+++ b/examples/karpathy/README.md
@@ -14,6 +14,7 @@ karpathy/
 ├── QUICKSTART.md            ← drop-in system prompt template
 ├── SOUL.md                  ← identity: worldview, modes, tensions, boundaries
 ├── STYLE.md                 ← voice rules: vocabulary, rhetorical moves, platform register
+├── MEMORY.md                ← running log across sessions
 ├── data/
 │   ├── influences.md                  ← people, papers, concepts, repos
 │   ├── writing/*.html                 ← 13 karpathy.github.io + medium.com blog posts
@@ -34,7 +35,7 @@ karpathy/
 │   └── weak-model-test.mjs  ← runs the voice test on gpt-4o-mini via OpenRouter
 └── tests/
     ├── prediction-test.md   ← 12 prompts with predicted takes and scoring rubric
-    └── weak-model-results.md ← latest weak-model run (gpt-4o-mini): 42/48 (3.50/4) PASS
+    └── weak-model-results.md ← latest weak-model run (gpt-4o-mini): 40/48 (3.33/4) PASS
 ```
 
 ---
@@ -93,7 +94,7 @@ Karpathy writes like a teacher who builds. Short sentences. Specific technical a
 - **Stance (0–2)** — specificity, anti-hedge, correct technical grounding
 - **Anti-pattern penalty (up to –2)** — hype / corporate / doomer / guru voice
 
-**Latest result: 42/48 = 3.50/4 average — PASS** (threshold ≥ 3.0/4). See `tests/weak-model-results.md` for the full transcript.
+**Latest result: 40/48 = 3.33/4 average — PASS** (threshold ≥ 3.0/4). See `tests/weak-model-results.md` for the full transcript.
 
 ### 3. Grader checklist (in `examples/bad-outputs.md`)
 


### PR DESCRIPTION
## Summary

Follow-up to #14. Three small cleanup items:

- **Score mismatch** — `README.md` and `QUICKSTART.md` cited the weak-model test as `42/48 = 3.50/4`, but the checked-in `tests/weak-model-results.md` actually scored `40/48 = 3.33/4`. Both still pass the ≥ 3.0/4 threshold; this just aligns the claim with the evidence.
- **MEMORY.md** — added, matching the structure used by `examples/garry-tan/MEMORY.md`. Root README's file-structure diagram lists MEMORY.md; this brings the example in line.
- **Root README Examples section** — added an `@karpathy` entry alongside `@aaronjmars` and `@garrytan`, per the contribution instructions.

## Test plan

- [x] Score lines consistent across `examples/karpathy/README.md`, `examples/karpathy/QUICKSTART.md`, and `examples/karpathy/tests/weak-model-results.md`
- [x] `examples/karpathy/MEMORY.md` present and listed in the example's README file-structure diagram
- [x] Root `README.md` Examples section links to `examples/karpathy/`