### PR TITLE
docs: add "In the Wild" section featuring vgr_zirp

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,22 @@ What makes this one distinctive: tool casing as identity signal (lowercase `code
 
 ---
 
+## In the Wild
+
+Production deployments built on this methodology.
+
+### vgr_zirp — Ribbonfarm's resurrected oracle
+A retrieval-augmented Q&A system that answers in Venkatesh Rao's intellectual voice, deployed at ribbonfarm.com. Built by the Ribbonfarm team using a modified soul.md approach as the persona layer over a RAG pipeline (Voyage embeddings → Pinecone → Claude Sonnet on Cloudflare Workers).
+
+What's interesting about this implementation:
+- **LEXICON.md** — a third persona file with top 50 high-confidence coinages + definitions, letting the model reference precise jargon without retrieval
+- **Empirically-derived topic clusters** — 708 post summaries clustered into 15 topics rather than hand-authoring worldview sections (useful when the corpus is large)
+- **Era-by-era voice evolution** in STYLE.md — captures how voice shifted over time, not just a snapshot
+
+→ Writeup: [ribbonfarm.com/vgr_zirp_tech](https://ribbonfarm.com/vgr_zirp_tech/) · [contraptions.venkateshrao.com](https://contraptions.venkateshrao.com/p/ribbonfarm-resurrected)
+
+---
+
 ## Contribute Your Soul
 
 Fork this repo, build your soul using the templates, host it publicly, and open a PR adding yourself to the Examples section — one paragraph bio + link + a few lines on what makes your soul spec distinctive.


### PR DESCRIPTION
## Summary
- New "In the Wild" section between Examples and Contribute, for production deployments built on the soul.md methodology
- First entry: **vgr_zirp**, Ribbonfarm's resurrected oracle — a RAG-based Q&A system that adapts soul.md as a persona layer over Voyage + Pinecone + Claude Sonnet on Cloudflare Workers
- Surfaces three methodology contributions worth pulling forward: `LEXICON.md` as an optional third persona file, empirically-derived topic clusters from corpus, and era-by-era voice evolution in STYLE.md

## Context
Raised in #20 by @TomLucidor. Both writeups read end-to-end:
- https://ribbonfarm.com/vgr_zirp_tech/
- https://contraptions.venkateshrao.com/p/ribbonfarm-resurrected

vgr_zirp doesn't fit the Examples section (no public folder of soul files — the persona is compiled into a JS bundle inside the worker), but it's a substantive third-party deployment worth featuring.

## Test plan
- [ ] Render README on GitHub, confirm new section sits between Examples and Contribute
- [ ] Confirm both external links resolve
- [ ] Decide separately whether to back-port LEXICON.md as an optional template (not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)