### PR TITLE
docs: remove broken SKILL.template.md reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Copy the templates and fill them in:
 ```
 SOUL.template.md  → SOUL.md
 STYLE.template.md → STYLE.md
-SKILL.template.md → SKILL.md
 ```
 
 ---
@@ -124,7 +123,6 @@ Also works with any model via system prompt — see [Using With Other Tools](#us
 your-soul/
 ├── SOUL.md           ← Who you are (identity, worldview, opinions)
 ├── STYLE.md          ← How you write (voice, syntax, patterns)
-├── SKILL.md          ← Operating modes (tweet, essay, chat, etc.)
 ├── MEMORY.md         ← Session memory for continuity across conversations
 ├── data/             ← Raw source material
 │   ├── writing/


### PR DESCRIPTION
## Summary
README's Option 3 (Manual) section tells users to `cp SKILL.template.md → SKILL.md`, but that file doesn't exist in the repo and never has — only `SOUL.template.md` and `STYLE.template.md` ship. Anyone following the manual flow hits a `cp: No such file` and is left to guess. Fix the docs to match what actually exists and what every example soul does.

## Changes
- `README.md` — Drop the `SKILL.template.md → SKILL.md` line from Option 3 Manual.
- `README.md` — Drop `SKILL.md` from the `your-soul/` file-structure diagram. None of the four example souls (garry-tan, karpathy, steipete, vivian-balakrishnan) ship a per-soul `SKILL.md`, and `BUILD.md`'s soul-builder output spec doesn't generate one. The canonical `SKILL.md` lives at the repo root and is reused as-is.

## Context
Found by reading the Quick Start end-to-end against the actual file tree. Three-way agreement between (a) repo file list, (b) all four example soul folders, and (c) `BUILD.md`'s `## Output` section against a single docs disagreement = high-confidence silent docs bug. `git log --all -- SKILL.template.md` confirms the file was never committed.

Two-line deletion, no code touched, no behavior change. Closest precedent in repo: PR #19 (docs surface fix).

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)