### PR TITLE
docs: add manual templates for examples/good-outputs and examples/bad-outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Then run `/soul-builder`. It analyzes your data, extracts patterns, and drafts y
 
 Copy the templates and fill them in:
 ```
-SOUL.template.md  → SOUL.md
-STYLE.template.md → STYLE.md
+SOUL.template.md                    → SOUL.md
+STYLE.template.md                   → STYLE.md
+examples/good-outputs.template.md   → examples/good-outputs.md
+examples/bad-outputs.template.md    → examples/bad-outputs.md
 ```
 
 ---

--- a/examples/bad-outputs.template.md
+++ b/examples/bad-outputs.template.md
@@ -1,0 +1,86 @@
+# Bad Outputs — [Your Name]
+
+<!--
+Anti-patterns. What "sounding wrong" looks like for you specifically.
+This file is what catches AI drift before it ships.
+
+Generic anti-patterns (corporate voice, emoji spam, hedging) belong in
+STYLE.md. This file is for the *person-specific* failure modes — the
+drifts that look fine in isolation but feel wrong coming from you.
+
+Aim for 8–12 examples. Each one: the bad output, a diagnosis of *why*
+it's wrong, and ideally a rewrite showing how you'd actually say it.
+
+The rewrites are the most useful part — they teach the model the
+correction, not just the rejection.
+-->
+
+[One-sentence summary of what this file catches: how many anti-patterns,
+what failure modes they cover.]
+
+---
+
+## 1. [Failure-mode name — e.g. Generic thought-leader voice]
+
+**Bad:**
+> [Example of the wrong voice. Make it specific. AI failure modes are
+> usually a cluster of small tells, not one obvious flag.]
+
+**Why it's wrong:** [Diagnose the tells — specific phrases, structural
+moves, tonal choices. "Every word on the never-use list" beats "feels
+off." Then show how you'd actually say it: "You'd say: [rewrite]."]
+
+---
+
+## 2. [Failure-mode name — e.g. Wrong register for the topic]
+
+**Bad:**
+> [Example.]
+
+**Why it's wrong:** [Diagnosis + rewrite.]
+
+---
+
+## 3. [Failure-mode name — e.g. Over-hedged]
+
+**Bad:**
+> [Example.]
+
+**Why it's wrong:** [Diagnosis + rewrite.]
+
+---
+
+## 4. [Failure-mode name — e.g. Right voice, wrong opinion]
+
+<!--
+Worth including: outputs where the voice is plausible but the *position*
+is wrong for you. The LLM nailing your style while putting words in your
+mouth is a distinctive failure mode worth flagging.
+-->
+
+**Bad:**
+> [Example.]
+
+**Why it's wrong:** [Diagnosis + rewrite.]
+
+---
+
+## 5. [Failure-mode name]
+
+**Bad:**
+> [Example.]
+
+**Why it's wrong:** [Diagnosis + rewrite.]
+
+---
+
+<!--
+QUALITY CHECK:
+- Does each example catch a *distinct* failure mode? Two examples of the
+  same drift = one wasted slot.
+- Are the diagnoses pointing at specific tells, or just saying "feels off"?
+- Do the rewrites show the correction clearly? If not, the model learns
+  what to avoid but not what to do.
+- Are you catching person-specific drifts, or just listing generic AI
+  failure modes? Generic ones belong in STYLE.md.
+-->

--- a/examples/good-outputs.template.md
+++ b/examples/good-outputs.template.md
@@ -1,0 +1,90 @@
+# Good Outputs — [Your Name]
+
+<!--
+This file is calibration material. Show the LLM what your voice sounds like
+when it's done right. The agent reads SOUL.md and STYLE.md for the rules,
+then matches the *vibe* in this file.
+
+Aim for 10–20 examples minimum. Quality over quantity — 12 sharp examples
+beat 40 mediocre ones. Span short reactions, medium takes, and longer
+pieces. Pull from your actual content where possible (tweets, replies,
+blog snippets) — invented examples drift.
+
+Each example: the text, then a one-line "Calibration:" note pointing at
+what the LLM should pick up (a phrase, a move, a tonal choice). The
+calibration note is more useful than the example itself.
+-->
+
+[One-sentence summary of what's in this file: how many examples, what
+contexts they span, how to use them.]
+
+---
+
+## Short reactions (one-liner or 1–2 sentences)
+
+<!-- Where the voice is most distilled. Twitter replies, quick takes, DMs. -->
+
+### 1. [Context — e.g. reacting to a hype tweet]
+> [Actual text in your voice.]
+
+**Calibration:** [What to pick up — a phrase, a rhetorical move, a tonal choice.]
+
+### 2. [Context]
+> [Actual text.]
+
+**Calibration:** [What to pick up.]
+
+### 3. [Context]
+> [Actual text.]
+
+**Calibration:** [What to pick up.]
+
+---
+
+## Medium takes (2–5 sentences)
+
+<!-- A paragraph. Long enough to develop one idea, short enough to stay punchy. -->
+
+### 4. [Context — e.g. responding to a common framing you disagree with]
+> [Actual text.]
+
+**Calibration:** [What to pick up.]
+
+### 5. [Context]
+> [Actual text.]
+
+**Calibration:** [What to pick up.]
+
+---
+
+## Long-form (5+ sentences, blog/essay register)
+
+<!-- Skip this section if you don't write long-form. -->
+
+### 6. [Context — e.g. opening paragraph of an essay]
+> [Actual text.]
+
+**Calibration:** [What to pick up.]
+
+---
+
+## Replies (conversational, back-and-forth)
+
+<!-- How your voice changes when you're responding to someone, not broadcasting. -->
+
+### 7. [Context — e.g. replying to a question in your DMs]
+> **Them:** [The prompt or question.]
+>
+> **You:** [Your reply, in voice.]
+
+**Calibration:** [What to pick up.]
+
+---
+
+<!--
+QUALITY CHECK:
+- Could the LLM match your voice on a NEW topic using only these examples? If not, add range.
+- Do the examples cover the registers you actually use? (excited, skeptical, teaching, joking, serious)
+- Are the calibration notes pointing at *moves*, not just summarizing the example?
+- Is anything generic enough that it could be anyone? Cut it.
+-->


### PR DESCRIPTION
## Summary
Adds matching `.template.md` files for `examples/good-outputs.md` and `examples/bad-outputs.md` so the "Option 3 — Manual" path in the README has a starter for every canonical file, not just SOUL/STYLE.

## Changes
- `examples/good-outputs.template.md` — new file. Mirrors the style of `SOUL.template.md` / `STYLE.template.md`: HTML comments explaining each section, placeholder content in brackets, quality check at the bottom. Sections cover short reactions / medium takes / long-form / replies — the same shape as the karpathy/garry-tan/steipete examples currently shipped.
- `examples/bad-outputs.template.md` — new file. Same style. Numbered failure modes with `**Bad:** → **Why it's wrong:**` blocks, matching the convention in the example soul files.
- `README.md` — Option 3 now lists all four templates (SOUL, STYLE, good-outputs, bad-outputs) instead of only the first two.

## Context
README line 122–134 documents the canonical file structure as `SOUL.md / STYLE.md / MEMORY.md / data/influences.md / examples/good-outputs.md / examples/bad-outputs.md`. Option 1 (`/soul-builder` interview) and Option 2 (`/soul-builder` on data) generate all of these. Option 3 (Manual) only had templates for the first two — manual users had to read `examples/_GUIDE.md` and reverse-engineer the format from existing example soul files (karpathy, garry-tan, etc.) to know what to ship.

This is strictly additive on the manual path; nothing changes for builder-driven flows.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
