### PR TITLE
docs: fix stale 'lychee' references in link-check comments

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,7 +3,8 @@
   // and placeholder templates are by design. So we don't enforce prose style.
   // We only enforce link/reference integrity, the one thing that has actually
   // broken in this repo before (see commit "remove broken SKILL.template.md
-  // reference from README"). This pairs with the lychee link check in CI.
+  // reference from README"). This pairs with the relative-link check
+  // (`scripts/check-links.mjs`) in CI.
   "config": {
     "default": false,
     "MD011": true, // no reversed link syntax  (text)[url]

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -3,7 +3,7 @@
 // docs resolve to real files. This catches the kind of dangling reference
 // that has slipped in before (e.g. a README pointing at a file that no longer
 // exists). External URLs and same-page anchors are out of scope here — the
-// lychee/markdownlint pair handles link *syntax*; this handles link *targets*.
+// markdownlint handles link *syntax*; this handles link *targets*.
 //
 // Scope: top-level markdown only. The examples/ subtrees carry raw, third-party
 // source material whose internal links point at their original repo layouts, so


### PR DESCRIPTION
Follow-up nit from the #27 review.

Both `.markdownlint-cli2.jsonc` and `scripts/check-links.mjs` had header comments referencing a **lychee** link checker, but no lychee step exists in the workflow — the actual link check is the custom `scripts/check-links.mjs` (verifies relative-link *targets*) paired with markdownlint (link *syntax*). Comments corrected to match reality. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)