### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` for weekly dependency updates (npm / github-actions as applicable). Also enabling Dependabot alerts + automated security fixes on the repo.